### PR TITLE
ci(github): make dependabot changeset not be force-pushed

### DIFF
--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -98,5 +98,5 @@ jobs:
             const packageBumps = await getBumps(files);
             await createChangeset(fileName, packageBumps, packageNames);
             await exec.exec("git", ["add", fileName]);
-            await exec.exec("git commit -C HEAD --amend --no-edit");
-            await exec.exec("git push --force");
+            await exec.exec("git commit -m 'chore: add changeset'");
+            await exec.exec("git push");


### PR DESCRIPTION
...so status checks are visible on the PR.
